### PR TITLE
Add Gitignore for ESP-IDF artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# ESP-IDF build output
+build/
+*.bin
+*.elf
+*.map
+
+# SDK configuration generated during build
+sdkconfig
+sdkconfig.old
+sdkconfig.*
+!sdkconfig.defaults
+
+# Compiler artifacts
+*.o
+*.d
+
+# Python cache
+__pycache__/
+*.pyc
+
+# IDE directories and files
+.vscode/
+.idea/
+*.code-workspace
+.DS_Store
+
+# Backup and swap files
+*~
+*.swp


### PR DESCRIPTION
## Summary
- ignore ESP-IDF build outputs
- add IDE-related artifacts and common backup files to `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d57fc8d6c8323bf2b07c404cd771b