### PR TITLE
Fix LVGL build dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.5)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(lyzard_board)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# LYZARD-BOAD
+# Lyzard Board
+
+Ce projet fournit une structure de base pour le développement d'une application ESP32 (ESP-IDF) destinée à la gestion d'un élevage de reptiles. Il s'appuie sur LVGL pour l'interface tactile, une base de données locale et des modules spécifiques permettant la génération automatique des documents légaux français (CERFA, I-FAP, CITES, etc.).
+
+**Fonctionnalités prévues** :
+
+- Gestion des animaux, terrariums, cycles de vie et événements sanitaires.
+- Stocks et transactions avec création des documents légaux correspondants.
+- Interface graphique LVGL (800x480, thème clair/sombre, multi-langues).
+- Authentification locale et chiffrement des données sensibles.
+- Export/Import CSV ou JSON et sauvegarde sur carte SD ou via Wi-Fi.
+
+Ce dépôt propose uniquement une implémentation minimale servant de point de départ.
+Reportez-vous à `docs/README_FR.md` pour plus d'informations.
+
+## Pré-requis supplémentaires
+
+Le composant graphique [LVGL](https://lvgl.io) n'est pas inclus directement.
+Installez-le via le gestionnaire de composants ESP‑IDF :
+
+```bash
+idf.py add-dependency lvgl/lvgl
+```

--- a/components/database/CMakeLists.txt
+++ b/components/database/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "database.c"
+                       INCLUDE_DIRS ".")

--- a/components/database/database.c
+++ b/components/database/database.c
@@ -1,0 +1,17 @@
+#include "database.h"
+#include "esp_log.h"
+
+static const char *TAG = "database";
+
+void database_init(void)
+{
+    // Initialisation de la base SQLite ou du stockage fichier.
+    ESP_LOGI(TAG, "Initialisation de la base de donnees");
+    // TODO: implémenter la création et l'ouverture de la base.
+}
+
+void database_save_event(const char *event)
+{
+    ESP_LOGI(TAG, "Sauvegarde d'un evenement: %s", event);
+    // TODO: insérer l'événement dans la base de données.
+}

--- a/components/database/database.h
+++ b/components/database/database.h
@@ -1,0 +1,21 @@
+#ifndef DATABASE_H
+#define DATABASE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Initialise la base de données locale (SQLite ou fichier).
+ */
+void database_init(void);
+
+/** Sauvegarde un événement dans la base.
+ *  Les structures détaillées sont à implémenter.
+ */
+void database_save_event(const char *event);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DATABASE_H

--- a/components/legal/CMakeLists.txt
+++ b/components/legal/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "legal.c"
+                       INCLUDE_DIRS ".")

--- a/components/legal/legal.c
+++ b/components/legal/legal.c
@@ -1,0 +1,16 @@
+#include "legal.h"
+#include "esp_log.h"
+
+static const char *TAG = "legal";
+
+void legal_init(void)
+{
+    ESP_LOGI(TAG, "Initialisation du module legal");
+    // TODO: charger les parametres reglementaires.
+}
+
+void legal_generate_docs(const char *operation)
+{
+    ESP_LOGI(TAG, "Generation des documents pour l'operation: %s", operation);
+    // TODO: generer CERFA, I-FAP, CITES, etc.
+}

--- a/components/legal/legal.h
+++ b/components/legal/legal.h
@@ -1,0 +1,18 @@
+#ifndef LEGAL_H
+#define LEGAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Initialise les paramètres liés à la conformité légale. */
+void legal_init(void);
+
+/** Génère les documents obligatoires pour une opération. */
+void legal_generate_docs(const char *operation);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LEGAL_H

--- a/components/ui/CMakeLists.txt
+++ b/components/ui/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "ui.c"
+                       INCLUDE_DIRS "."
+                       REQUIRES lvgl)

--- a/components/ui/ui.c
+++ b/components/ui/ui.c
@@ -1,0 +1,19 @@
+#include "ui.h"
+#include "lvgl.h"
+#include "esp_log.h"
+
+static const char *TAG = "ui";
+
+void ui_init(void)
+{
+    ESP_LOGI(TAG, "Initialisation de LVGL");
+    lv_init();
+    // TODO: initialiser les drivers d'écran et de saisie tactiles.
+    // TODO: créer les écrans et onglets LVGL.
+}
+
+void ui_update(void)
+{
+    // Appel périodique pour mettre à jour LVGL.
+    lv_timer_handler();
+}

--- a/components/ui/ui.h
+++ b/components/ui/ui.h
@@ -1,0 +1,18 @@
+#ifndef UI_H
+#define UI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Initialise l'interface LVGL. */
+void ui_init(void);
+
+/** Met à jour les éléments de l'interface (appel périodique). */
+void ui_update(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // UI_H

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -1,0 +1,28 @@
+# Documentation (Français)
+
+Ce projet constitue une base pour une application ESP32 permettant la gestion complète d'un élevage de reptiles, conforme aux règlementations françaises et européennes. Les modules sont organisés de manière à pouvoir être complétés selon les besoins.
+
+## Arborescence
+
+- `main/` : point d'entrée de l'application.
+- `components/database/` : gestion de la base SQLite ou du système de fichiers.
+- `components/ui/` : interface tactile LVGL.
+- `components/legal/` : génération des documents légaux (CERFA, I-FAP, CITES).
+- `docs/` : cette documentation.
+
+## Configuration rapide
+
+1. Installer ESP-IDF et configurer l'environnement.
+2. Se placer à la racine du projet puis exécuter `idf.py menuconfig` pour ajuster la configuration.
+3. Compiler et flasher avec `idf.py flash monitor`.
+
+### Dépendances
+
+Ce projet s'appuie sur [LVGL](https://lvgl.io) pour l'interface graphique. Pour
+l'ajouter via le gestionnaire de composants :
+
+```bash
+idf.py add-dependency lvgl/lvgl
+```
+
+Les modules présents sont à l'état minimal et doivent être complétés pour une utilisation en production.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "main.c"
+                       INCLUDE_DIRS "."
+                       REQUIRES database ui legal)

--- a/main/main.c
+++ b/main/main.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+
+#include "database.h"
+#include "ui.h"
+#include "legal.h"
+
+static const char *TAG = "main";
+
+void app_main(void)
+{
+    ESP_LOGI(TAG, "Demarrage de Lyzard Board");
+
+    // Initialisation NVS requise par ESP-IDF
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
+
+    // Initialisation des modules
+    database_init();
+    legal_init();
+    ui_init();
+
+    while (1) {
+        ui_update();
+        vTaskDelay(pdMS_TO_TICKS(20));
+    }
+}


### PR DESCRIPTION
## Summary
- require LVGL using `REQUIRES` so CMake parses correctly

## Testing
- `idf.py --version` *(fails: command not found)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3978227883239e73aa64cde5a66b